### PR TITLE
Fix of music module

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -100,10 +100,10 @@
         // "exec-tooltip": "~/.scripts/updates tooltip"
     },
     "custom/music": {
-        "format": "{icon}{}",
+        "format": "{icon}{0}",
         "format-icons": {
             // "Playing": " ", // Uncomment if not using the dynamic script
-            "Paused": " ",
+            "Paused": " ",
             "Stopped": "&#x202d;ﭥ " // This stop symbol is RTL. So &#x202d; is left-to-right override.
         },
         "escape": true,


### PR DESCRIPTION
Since the 0.10 version of waybar, the music module is displayed like this with an error of type "cannot switch from manual to automatic argument indexing"
![Screenshot_2024-10-09_14-24-09](https://github.com/user-attachments/assets/ad8a828b-0052-4594-9703-001425816007)
Note: The `echo` command in exec property of module was written to test if this is an issue of caway or the json parsing.
This issue was not fixed in further update so there is the fix

Same issue I found [here](https://github.com/Alexays/Waybar/issues/3623)